### PR TITLE
Adding properties option to the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # drone-mvn-auth
+
 [![Build Status](https://travis-ci.org/robertstettner/drone-mvn-auth.svg?branch=master)](https://travis-ci.org/robertstettner/drone-mvn-auth)
 [![Coverage Status](https://coveralls.io/repos/github/robertstettner/drone-mvn-auth/badge.svg?branch=master)](https://coveralls.io/github/robertstettner/drone-mvn-auth?branch=master)
 
@@ -26,12 +27,13 @@ The following parameters are used to configure the plugin:
 - `profiles[].plugin_repositories[].name`: the profile's plugin repository name
 - `profiles[].plugin_repositories[].url`: the profile's plugin repository url
 - `profiles[].plugin_repositories[].layout`: the profile's plugin repository layout
+- `profiles[].properties[]`: (Optional) key value list of properties
 - `active_profiles[]`: the active profiles
 - `debug`: debug mode (optional: set to `true` for verbose messages)
 
 ### Secrets mode
 
-The secrets mode allows for usage of Drone secrets for parameters. For every parameter, the secret prefix to use is `maven_`. For example, for storing the `servers` parameter as a secret, the key would be `maven_servers`. The value for that parameter would still need to be serialised JSON. 
+The secrets mode allows for usage of Drone secrets for parameters. For every parameter, the secret prefix to use is `maven_`. For example, for storing the `servers` parameter as a secret, the key would be `maven_servers`. The value for that parameter would still need to be serialised JSON.
 
 ### Drone configuration example
 
@@ -41,7 +43,7 @@ pipeline:
     image: maven:3-alpine
     commands:
       - mvn install -gs settings.xml
-      
+
   authenticate:
     image: robertstettner/drone-mvn-auth
     pull: true
@@ -66,8 +68,7 @@ pipeline:
             layout: default
     active_profiles:
       - my-profile
-              
-    
+
   deploy:
     image: maven:3-alpine
     commands:
@@ -85,11 +86,11 @@ pipeline:
     image: maven:3-alpine
     commands:
       - mvn install -gs settings.xml
-      
+
   authenticate:
     image: robertstettner/drone-mvn-auth
     pull: true
-    secrets: [ maven_servers ]
+    secrets: [maven_servers]
     profiles:
       - id: my-profile
         repositories:
@@ -104,8 +105,7 @@ pipeline:
             layout: default
     active_profiles:
       - my-profile
-              
-    
+
   deploy:
     image: maven:3-alpine
     commands:

--- a/plugin.js
+++ b/plugin.js
@@ -16,8 +16,10 @@ const generateServer = server =>
 const generateRepository = type => repo =>
   `<${type}><id>${repo.id}</id><name>${repo.name}</name><url>${repo.url}</url><layout>${repo.layout || 'default'}</layout></${type}>`;
 
+const generateProperty = map => key => `<${key}>${map[key]}</${key}>`;
+
 const generateProfile = profile =>
-  `<profile><id>${profile.id}</id><repositories>${profile.hasOwnProperty('repositories') ? profile.repositories.map(generateRepository('repository')).join('') : ''}</repositories><pluginRepositories>${profile.hasOwnProperty('plugin_repositories') ? profile.plugin_repositories
+  `<profile><id>${profile.id}</id>${profile.hasOwnProperty('properties') ? `<properties>${Object.keys(profile.properties).map(generateProperty(profile.properties)).join('')}</properties>` : ''}<repositories>${profile.hasOwnProperty('repositories') ? profile.repositories.map(generateRepository('repository')).join('') : ''}</repositories><pluginRepositories>${profile.hasOwnProperty('plugin_repositories') ? profile.plugin_repositories
     .map(generateRepository('pluginRepository')).join('') : ''}</pluginRepositories></profile>`;
 
 const generateActiveProfile = profile =>

--- a/plugin.js
+++ b/plugin.js
@@ -14,7 +14,7 @@ const generateServer = server =>
   `<server><id>${server.id}</id><username>${server.username}</username><password>${server.password}</password></server>`;
 
 const generateRepository = type => repo =>
-  `<${type}><id>${repo.id}</id><name>${repo.name}</name><url>${repo.url}</url><layout>${repo.layout}</layout></${type}>`;
+  `<${type}><id>${repo.id}</id><name>${repo.name}</name><url>${repo.url}</url><layout>${repo.layout || 'default'}</layout></${type}>`;
 
 const generateProfile = profile =>
   `<profile><id>${profile.id}</id><repositories>${profile.hasOwnProperty('repositories') ? profile.repositories.map(generateRepository('repository')).join('') : ''}</repositories><pluginRepositories>${profile.hasOwnProperty('plugin_repositories') ? profile.plugin_repositories

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -41,6 +41,22 @@ describe('Component tests: Drone Maven Auth', () => {
       actual.should.eql('<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"><localRepository>undefined/.m2</localRepository><servers></servers><profiles><profile><id>aa</id><repositories><repository><id>aa</id><name>nexus</name><url>http://ip:8081/nexus/content/groups/public/</url><layout>default</layout></repository></repositories><pluginRepositories></pluginRepositories></profile></profiles><activeProfiles><activeProfile>aa</activeProfile></activeProfiles></settings>');
       revert();
     });
+    it('should profiles, properties and active profiles', () => {
+      const processMock = {
+        env: {
+          PLUGIN_PROFILES: '[{"id": 321, "repositories": [{"id": 765, "name": "escenic", "url": "http://me.co", "layout": "default"}], "properties": { "property.1": "value1", "property.2": "value2" }}]',
+          PLUGIN_ACTIVE_PROFILES: '321'
+        },
+        exit: () => { }
+      };
+      const revert = plugin.__set__('process', processMock);
+
+      plugin.init();
+      const actual = fs.readFileSync('settings.xml', 'UTF-8');
+
+      actual.should.eql('<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"><localRepository>undefined/.m2</localRepository><servers></servers><profiles><profile><id>321</id><properties><property.1>value1</property.1><property.2>value2</property.2></properties><repositories><repository><id>765</id><name>escenic</name><url>http://me.co</url><layout>default</layout></repository></repositories><pluginRepositories></pluginRepositories></profile></profiles><activeProfiles><activeProfile>321</activeProfile></activeProfiles></settings>');
+      revert();
+    });
   });
   describe('with secrets', () => {
     it('should produce servers, profiles, and active profiles', () => {

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -50,6 +50,15 @@ describe('Unit tests: Drone Maven Auth', () => {
         layout: 'default'
       }).should.eql('<myType><id>123</id><name>bobo</name><url>http://www.google.com</url><layout>default</layout></myType>');
     });
+    it('should set layout to default if missing', () => {
+      generateRepository('myType')({
+        id: 123,
+        name: 'bobo',
+        url: 'http://www.google.com'
+      }).should.eql(
+        '<myType><id>123</id><name>bobo</name><url>http://www.google.com</url><layout>default</layout></myType>'
+      );
+    });
   });
   describe('generateProfile()', () => {
     const generateProfile = plugin.__get__('generateProfile');

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -93,6 +93,25 @@ describe('Unit tests: Drone Maven Auth', () => {
       generateRepositoryStub.should.have.callCount(1);
       revert();
     });
+    it('should return properties for profile', () => {
+      const generateRepositoryStub = sinon.stub().returns(() => 'dabba');
+      const revert = plugin.__set__(
+        'generateRepository',
+        generateRepositoryStub
+      );
+      generateProfile({
+        id: 123,
+        repositories: [1, 2],
+        properties: {
+          'property.1': 'value1',
+          'property.2': 'value2'
+        }
+      }).should.eql(
+        '<profile><id>123</id><properties><property.1>value1</property.1><property.2>value2</property.2></properties><repositories>dabbadabba</repositories><pluginRepositories></pluginRepositories></profile>'
+      );
+      generateRepositoryStub.should.have.callCount(1);
+      revert();
+    });
   });
   describe('generateActiveProfile()', () => {
     const generateActiveProfile = plugin.__get__('generateActiveProfile');


### PR DESCRIPTION

Add properties to the profile so we can add things like

```xml
    <profile>
      <id>sonar</id>
      <properties>
        <sonar.host.url>https://sonar.committed.software</sonar.host.url>
        <sonar.forceAuthentication>true</sonar.forceAuthentication>
        <sonar.login>username</sonar.login>
        <sonar.password>password</sonar.password>
      </properties>
    </profile>
```

- Adds tests to both unit and component
- Add properties to the README
- Also defaults layout to 'default'